### PR TITLE
remove asm-5.0.4.jar to avoid jar conflict

### DIFF
--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 
       <dependency>
         <groupId>com.esotericsoftware</groupId>
-        <artifactId>kryo</artifactId>
+        <artifactId>kryo-shaded</artifactId>
         <version>${kryo.version}</version>
       </dependency>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -140,9 +140,8 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.livy:livy-client-common</include>
-                  <include>com.esotericsoftware:kryo</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                   <include>com.esotericsoftware:minlog</include>
-                  <include>com.esotericsoftware:reflectasm</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -177,7 +176,7 @@
             <configuration>
               <excludeArtifactIds>
                 livy-client-common,
-                kryo,
+                kryo-shaded,
                 spark-launcher_${scala.binary.version},
               </excludeArtifactIds>
               <outputDirectory>${project.build.directory}/jars</outputDirectory>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When package with the command: mvn clean package -Pthriftserver, the jars contains both asm-5.0.4.jar and asm-6.0.jar, this will cause jar conflict problem.
The following is the detail info for the conflict:
```
+- com.esotericsoftware:kryo:jar:4.0.2:compile
  +- com.esotericsoftware:reflectasm:jar:1.11.3:compile
  \- org.ow2.asm:asm:jar:5.0.4:compile

+- org.eclipse.jetty:jetty-runner:jar:9.3.24.v20180605:compile
  +- org.eclipse.jetty:jetty-plus:jar:9.3.24.v20180605:compile
  +- org.eclipse.jetty:jetty-annotations:jar:9.3.24.v20180605:compile
    +- org.ow2.asm:asm:jar:6.0:compile
    \- org.ow2.asm:asm-commons:jar:6.0:compile
```
Introduce kryo-shaded to resolve this problem.

## How was this patch tested?

Test by mvn dependency:tree command and check the new package
